### PR TITLE
feat: add OpenAI temperature setting

### DIFF
--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/OpenAIService.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/OpenAIService.kt
@@ -32,13 +32,14 @@ class OpenAIService {
                     content = prompt
                 )
             ),
-            temperature = 0.7,
+            temperature = AppSettings.instance.openAITemperature.toDouble(),
             topP = 1.0,
             frequencyPenalty = 0.0,
             presencePenalty = 0.0,
             maxTokens = 200,
             n = completions
         )
+        println(chatCompletionRequest)
 
         val completion: ChatCompletion = openAI.chatCompletion(chatCompletionRequest)
         return completion.choices[0].message!!.content

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/AppSettings.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/AppSettings.kt
@@ -7,6 +7,7 @@ import com.github.blarc.ai.commits.intellij.plugin.AICommitsUtils
 import com.github.blarc.ai.commits.intellij.plugin.notifications.Notification
 import com.github.blarc.ai.commits.intellij.plugin.notifications.sendNotification
 import com.github.blarc.ai.commits.intellij.plugin.settings.prompt.Prompt
+import com.google.type.Decimal
 import com.intellij.credentialStore.CredentialAttributes
 import com.intellij.credentialStore.Credentials
 import com.intellij.ide.passwordSafe.PasswordSafe
@@ -41,6 +42,7 @@ class AppSettings : PersistentStateComponent<AppSettings> {
 
     var openAIModelId = "gpt-3.5-turbo"
     var openAIModelIds = listOf("gpt-3.5-turbo", "gpt-4")
+    var openAITemperature: String = "0.7"
 
     var appExclusions: Set<String> = setOf()
 

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/AppSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/AppSettingsConfigurable.kt
@@ -18,6 +18,7 @@ import com.intellij.ui.components.JBTextField
 import com.intellij.ui.dsl.builder.*
 import com.intellij.ui.util.minimumWidth
 import kotlinx.coroutines.*
+import java.awt.event.KeyEvent
 import java.util.*
 import javax.swing.DefaultComboBoxModel
 import javax.swing.JPasswordField
@@ -28,6 +29,15 @@ class AppSettingsConfigurable : BoundConfigurable(message("settings.general.grou
     private val tokenPasswordField = JPasswordField()
     private val verifyLabel = JBLabel()
     private val proxyTextField = JBTextField()
+    private val temperatureTextField = object : JBTextField() {
+        override fun processKeyEvent(e: KeyEvent) {
+            val text = text + e.keyChar
+            if (!text.matches("^[0-2](\\.)?(\\.\\d)?\$".toRegex()))
+                e.consume()
+            else
+                super.processKeyEvent(e)
+        }
+    }
     private var modelComboBox = ComboBox<String>()
     private val promptTable = PromptTable()
     private lateinit var toolbarDecorator: ToolbarDecorator
@@ -105,6 +115,23 @@ class AppSettingsConfigurable : BoundConfigurable(message("settings.general.grou
                 }
                         .align(AlignX.RIGHT)
                         .widthGroup("button")
+            }
+
+            row {
+                label(message("settings.openAITemperature")).widthGroup("label")
+
+                cell(temperatureTextField)
+                        .bindText(AppSettings.instance::openAITemperature)
+                        .applyToComponent { minimumWidth = 400 }
+                        .resizableColumn()
+                        .widthGroup("input")
+            }
+
+            row {
+                comment(message("settings.openAITemperatureComment"))
+                        .align(AlignX.LEFT)
+                cell(verifyLabel)
+                        .align(AlignX.RIGHT)
             }
         }
 

--- a/src/main/resources/messages/MyBundle.properties
+++ b/src/main/resources/messages/MyBundle.properties
@@ -6,8 +6,13 @@ settings.openAIToken=OpenAI token
 settings.locale=Locale
 settings.prompt=Prompt
 settings.openAIModel=OpenAI model
+settings.openAITemperature=OpenAI temperature
 settings.openAITokenComment=\
   <p>You can get your token <a href="https://platform.openai.com/account/api-keys">here.</a/></p>
+settings.openAITemperatureComment=\
+  <p>What sampling temperature to use, between 0 and 2. <br/>\
+  Higher values like 0.8 will make the output more random, <br/>\
+  while lower values like 0.2 will make it more focused and deterministic.</p>
 settings.report-bug=Report bug
 settings.verifyToken=Verify
 settings.verify.valid=Open AI configuration is valid.


### PR DESCRIPTION
Add new setting for OpenAI temperature in AppSettings with input validation, and display the comment describing the functionality in the settings GUI. Use the temperature value from the settings in the OpenAIService for chat completion requests.