### PR TITLE
fix(settings): Add fallback in case models httpRequest returns a JsonArray instead of JsonObject

### DIFF
--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/OpenAIService.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/OpenAIService.kt
@@ -11,6 +11,16 @@ import com.github.blarc.ai.commits.intellij.plugin.settings.AppSettings
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import kotlin.time.Duration.Companion.seconds
+import com.aallam.openai.api.model.Model
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.url
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.call.body
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
 
 
 @Service(Service.Level.APP)
@@ -46,7 +56,7 @@ class OpenAIService {
 
     suspend fun refreshOpenAIModelIds() {
         val openAI = OpenAI(AppSettings.instance.getOpenAIConfig())
-        AppSettings.instance.openAIModelIds=openAI.models().map { it.id.id }
+        AppSettings.instance.openAIModelIds=getOpenAIModels(openAI).map { it.id.id }
     }
 
     @Throws(Exception::class)
@@ -59,6 +69,35 @@ class OpenAIService {
                 timeout = Timeout(socket = socketTimeout.toInt().seconds)
         )
         val openAI = OpenAI(config)
-        openAI.models()
+        getOpenAIModels(openAI)
+    }
+
+    @Throws(Exception::class)
+    suspend fun getOpenAIModels(openAI: OpenAI): List<Model> {
+        try
+        {
+            return openAI.models()
+        }
+        catch (_: Exception) {
+            // Fallback to list of models
+        }
+        try {
+            val requester = openAI.javaClass.getDeclaredField("requester").apply { isAccessible = true }.get(openAI)
+            val httpClient = requester.javaClass.getDeclaredField("httpClient").apply { isAccessible = true }.get(requester) as HttpClient;
+            val response: HttpResponse = httpClient.get{url(path = "models") }
+            val jsonArray = response.body<JsonArray>()
+            val models = mutableListOf<Model>()
+            jsonArray.forEach {
+                models.add(Model(
+                        created = it.jsonObject["created"]?.jsonPrimitive?.long ?: 0,
+                        id = ModelId(it.jsonObject["id"]?.jsonPrimitive?.content ?: ""),
+                        ownedBy = "system"
+                ))
+            }
+            return models
+        }
+        catch (_: Exception) {
+            throw Exception("Failed to retrieve models from OpenAI API.")
+        }
     }
 }


### PR DESCRIPTION
I wanted to have support for https://www.together.ai/. However, AI Commits did not work with this endpoint out the box. I found out that the results from the "models" call differed.

From OpenAI, a call to `https://api.openai.com/v1/models` looked something like this:
```json
{
    "object": "list",
    "data": [
        {
            "id": "dall-e-3",
            "object": "model",
            "created": 1698785189,
            "owned_by": "system"
        },
        ...
    ]
}
```

Where as Together.ai, a call to `https://api.together.xyz/v1/models` looked something like this:
```json
[
    {
        "id": "Austism/chronos-hermes-13b",
        "object": "model",
        "created": 1692896905
    },
    ...
]
```

So, I ended up trying openai.models() first, and if it failed, fall back to parsing the jsonarray manually. Which leads me to another pain point, which was that `owned_by` is also not present in together.ai's model. So fallback only requires `id` and `created`.

If this is helpful to others, feel free to use this. Here's a video of it in action...

https://github.com/Blarc/ai-commits-intellij-plugin/assets/1261843/aa2e85a1-c788-4bf0-a61a-71f9222bcb13


