### PR TITLE
Add OpenRouter client configuration and panel for AI commit generation

### DIFF
--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/AppSettings2.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/AppSettings2.kt
@@ -1,6 +1,7 @@
 package com.github.blarc.ai.commits.intellij.plugin.settings
 
 import com.github.blarc.ai.commits.intellij.plugin.AICommitsUtils
+import com.github.blarc.ai.commits.intellij.plugin.settings.clients.openrouter.OpenRouterClientConfiguration
 import com.github.blarc.ai.commits.intellij.plugin.AICommitsUtils.getCredentialAttributes
 import com.github.blarc.ai.commits.intellij.plugin.notifications.Notification
 import com.github.blarc.ai.commits.intellij.plugin.notifications.sendNotification
@@ -59,12 +60,14 @@ class AppSettings2 : PersistentStateComponent<AppSettings2> {
             GeminiClientConfiguration::class,
             AnthropicClientConfiguration::class,
             AzureOpenAiClientConfiguration::class,
-            HuggingFaceClientConfiguration::class
+            HuggingFaceClientConfiguration::class,
+            OpenRouterClientConfiguration::class
         ],
         style = XCollection.Style.v2
     )
     var llmClientConfigurations = setOf<LLMClientConfiguration>(
-        OpenAiClientConfiguration()
+        OpenAiClientConfiguration(),
+        OpenRouterClientConfiguration()
     )
 
     @Attribute

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/LLMClientTable.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/LLMClientTable.kt
@@ -2,6 +2,9 @@ package com.github.blarc.ai.commits.intellij.plugin.settings.clients
 
 import com.github.blarc.ai.commits.intellij.plugin.AICommitsBundle.message
 import com.github.blarc.ai.commits.intellij.plugin.createColumn
+import com.github.blarc.ai.commits.intellij.plugin.settings.clients.openrouter.OpenRouterClientConfiguration
+
+
 import com.github.blarc.ai.commits.intellij.plugin.settings.AppSettings2
 import com.github.blarc.ai.commits.intellij.plugin.settings.clients.anthropic.AnthropicClientConfiguration
 import com.github.blarc.ai.commits.intellij.plugin.settings.clients.azureOpenAi.AzureOpenAiClientConfiguration
@@ -143,7 +146,6 @@ class LLMClientTable {
 
         private fun getLlmClients(newLLMClientConfiguration: LLMClientConfiguration?): List<LLMClientConfiguration> {
             return if (newLLMClientConfiguration == null) {
-                // TODO(@Blarc): Is there a better way to create the list of all possible LLM Clients that implement LLMClient abstract class
                 listOf(
                     OpenAiClientConfiguration(),
                     OllamaClientConfiguration(),
@@ -151,12 +153,15 @@ class LLMClientTable {
                     GeminiClientConfiguration(),
                     AnthropicClientConfiguration(),
                     AzureOpenAiClientConfiguration(),
-                    HuggingFaceClientConfiguration()
+                    HuggingFaceClientConfiguration(),
+                    OpenRouterClientConfiguration()
                 )
             } else {
                 listOf(newLLMClientConfiguration)
             }
         }
+
+
 
         private fun createCardSplitter(): JComponent {
             return Splitter(false, 0.25f).apply {

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/openrouter/OpenRouterClientConfiguration.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/openrouter/OpenRouterClientConfiguration.kt
@@ -1,0 +1,56 @@
+package com.github.blarc.ai.commits.intellij.plugin.settings.clients.openrouter
+
+import com.github.blarc.ai.commits.intellij.plugin.Icons
+import com.github.blarc.ai.commits.intellij.plugin.settings.clients.LLMClientConfiguration
+import com.github.blarc.ai.commits.intellij.plugin.settings.clients.LLMClientSharedState
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vcs.ui.CommitMessage
+import com.intellij.util.xmlb.annotations.Attribute
+import com.intellij.util.xmlb.annotations.Transient
+import com.intellij.vcs.commit.AbstractCommitWorkflowHandler
+import javax.swing.Icon
+
+class OpenRouterClientConfiguration : LLMClientConfiguration(
+    "OpenRouter",
+    "nousresearch/hermes-3-llama-3.1-405b:free",
+    "0.5"
+) {
+    @Attribute
+    var host: String = "https://openrouter.ai/api/v1"
+    @Attribute
+    var timeout: Int = 30
+    @Attribute
+    var tokenIsStored: Boolean = false
+    @Transient
+    var token: String? = null
+
+    companion object {
+        const val CLIENT_NAME = "OpenRouter"
+    }
+
+    override fun getClientName(): String = CLIENT_NAME
+
+    override fun getClientIcon(): Icon = Icons.OPEN_AI // You may want to create a custom icon for OpenRouter
+
+    override fun getSharedState(): LLMClientSharedState = OpenRouterClientSharedState.getInstance()
+
+    override fun generateCommitMessage(commitWorkflowHandler: AbstractCommitWorkflowHandler<*, *>, commitMessage: CommitMessage, project: Project) {
+        OpenRouterClientService.getInstance().generateCommitMessage(this, commitWorkflowHandler, commitMessage, project)
+    }
+
+    override fun getRefreshModelsFunction() = null
+
+    override fun clone(): LLMClientConfiguration {
+        val copy = OpenRouterClientConfiguration()
+        copy.id = id
+        copy.name = name
+        copy.host = host
+        copy.timeout = timeout
+        copy.modelId = modelId
+        copy.temperature = temperature
+        copy.tokenIsStored = tokenIsStored
+        return copy
+    }
+
+    override fun panel() = OpenRouterClientPanel(this)
+}

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/openrouter/OpenRouterClientPanel.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/openrouter/OpenRouterClientPanel.kt
@@ -1,0 +1,46 @@
+package com.github.blarc.ai.commits.intellij.plugin.settings.clients.openrouter
+
+import com.github.blarc.ai.commits.intellij.plugin.AICommitsBundle.message
+import com.github.blarc.ai.commits.intellij.plugin.emptyText
+import com.github.blarc.ai.commits.intellij.plugin.settings.clients.LLMClientPanel
+import com.intellij.ui.components.JBPasswordField
+import com.intellij.ui.dsl.builder.*
+
+class OpenRouterClientPanel(private val clientConfiguration: OpenRouterClientConfiguration) : LLMClientPanel(clientConfiguration) {
+    private val tokenPasswordField = JBPasswordField()
+
+    override fun create() = panel {
+        nameRow()
+        hostRow(clientConfiguration::host.toNullableProperty())
+        timeoutRow(clientConfiguration::timeout)
+        tokenRow()
+        modelIdRow()
+        temperatureRow()
+        verifyRow()
+    }
+
+    private fun Panel.tokenRow() {
+        row {
+            label(message("settings.llmClient.token"))
+                .widthGroup("label")
+            cell(tokenPasswordField)
+                .bindText(getter = { "" }, setter = {
+                    OpenRouterClientService.getInstance().saveToken(clientConfiguration, it)
+                })
+                .emptyText(if (clientConfiguration.tokenIsStored) message("settings.llmClient.token.stored") else message("settings.openRouter.token.example"))
+                .resizableColumn()
+                .align(Align.FILL)
+                .comment(message("settings.openRouter.token.comment"), 50)
+        }
+    }
+
+    override fun verifyConfiguration() {
+        clientConfiguration.host = hostComboBox.item
+        clientConfiguration.timeout = socketTimeoutTextField.text.toInt()
+        clientConfiguration.modelId = modelComboBox.item
+        clientConfiguration.temperature = temperatureTextField.text
+        clientConfiguration.token = String(tokenPasswordField.password)
+
+        OpenRouterClientService.getInstance().verifyConfiguration(clientConfiguration, verifyLabel)
+    }
+}

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/openrouter/OpenRouterClientService.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/openrouter/OpenRouterClientService.kt
@@ -1,0 +1,61 @@
+package com.github.blarc.ai.commits.intellij.plugin.settings.clients.openrouter
+
+import com.github.blarc.ai.commits.intellij.plugin.AICommitsUtils.getCredentialAttributes
+import com.github.blarc.ai.commits.intellij.plugin.AICommitsUtils.retrieveToken
+import com.github.blarc.ai.commits.intellij.plugin.notifications.Notification
+import com.github.blarc.ai.commits.intellij.plugin.notifications.sendNotification
+import com.github.blarc.ai.commits.intellij.plugin.settings.clients.LLMClientService
+import com.intellij.ide.passwordSafe.PasswordSafe
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.util.text.nullize
+import dev.langchain4j.model.chat.ChatLanguageModel
+import dev.langchain4j.model.chat.StreamingChatLanguageModel
+import dev.langchain4j.model.openai.OpenAiChatModel
+import dev.langchain4j.model.openai.OpenAiStreamingChatModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.time.Duration
+
+@Service(Service.Level.APP)
+class OpenRouterClientService(private val cs: CoroutineScope) : LLMClientService<OpenRouterClientConfiguration>(cs) {
+
+    companion object {
+        @JvmStatic
+        fun getInstance(): OpenRouterClientService = service()
+    }
+
+    override suspend fun buildChatModel(client: OpenRouterClientConfiguration): ChatLanguageModel {
+        val token = client.token.nullize(true) ?: retrieveToken(client.id)?.toString(true)
+        return OpenAiChatModel.builder()
+            .apiKey(token ?: "")
+            .modelName(client.modelId)
+            .temperature(client.temperature.toDouble())
+            .timeout(Duration.ofSeconds(client.timeout.toLong()))
+            .baseUrl(client.host)
+            .build()
+    }
+
+    override suspend fun buildStreamingChatModel(client: OpenRouterClientConfiguration): StreamingChatLanguageModel {
+        val token = client.token.nullize(true) ?: retrieveToken(client.id)?.toString(true)
+        return OpenAiStreamingChatModel.builder()
+            .apiKey(token ?: "")
+            .modelName(client.modelId)
+            .temperature(client.temperature.toDouble())
+            .timeout(Duration.ofSeconds(client.timeout.toLong()))
+            .baseUrl(client.host)
+            .build()
+    }
+
+    fun saveToken(client: OpenRouterClientConfiguration, token: String) {
+        cs.launch(Dispatchers.Default) {
+            try {
+                PasswordSafe.instance.setPassword(getCredentialAttributes(client.id), token)
+                client.tokenIsStored = true
+            } catch (e: Exception) {
+                sendNotification(Notification.unableToSaveToken(e.message))
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/openrouter/OpenRouterClientSharedState.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/openrouter/OpenRouterClientSharedState.kt
@@ -1,0 +1,34 @@
+package com.github.blarc.ai.commits.intellij.plugin.settings.clients.openrouter
+
+import com.github.blarc.ai.commits.intellij.plugin.settings.clients.LLMClientSharedState
+import com.intellij.openapi.components.*
+import com.intellij.util.xmlb.annotations.XCollection
+
+@Service(Service.Level.APP)
+@State(name = "OpenRouterClientSharedState", storages = [Storage("AICommitsOpenRouter.xml")])
+class OpenRouterClientSharedState : PersistentStateComponent<OpenRouterClientSharedState>, LLMClientSharedState {
+
+    companion object {
+        @JvmStatic
+        fun getInstance(): OpenRouterClientSharedState = service()
+    }
+
+    @XCollection(style = XCollection.Style.v2)
+    override val hosts = mutableSetOf("https://openrouter.ai/api/v1")
+
+    @XCollection(style = XCollection.Style.v2)
+    override val modelIds = mutableSetOf(
+        "nousresearch/hermes-3-llama-3.1-405b:free",
+        "anthropic/claude-2:free",
+        "google/palm-2-chat-bison:free",
+        "meta-llama/llama-2-13b-chat:free",
+        "openai/gpt-3.5-turbo:free"
+    )
+
+    override fun getState(): OpenRouterClientSharedState = this
+
+    override fun loadState(state: OpenRouterClientSharedState) {
+        modelIds += state.modelIds
+        hosts += state.hosts
+    }
+}

--- a/src/main/resources/messages/AiCommitsBundle.properties
+++ b/src/main/resources/messages/AiCommitsBundle.properties
@@ -109,3 +109,7 @@ settings.huggingface.token.example=hf_fKASPPYLkasgjasKwpSnAASRdasdCdAsddsASSDF
 settings.huggingface.maxNewTokens=Max new tokens
 settings.huggingface.waitForModel=Wait for model
 settings.huggingface.waitModel.comment=When a model is warm, it is ready to be used, and you will get a response relatively quickly. However, some models are cold and need to be loaded before they can be used. In that case, you will get a 503 error. Rather than doing many requests until it is loaded, you can wait for the model to be loaded.
+
+
+settings.openRouter.token.example=sk-or-v1-...
+settings.openRouter.token.comment=Your OpenRouter API key. You can find it in your OpenRouter account settings.


### PR DESCRIPTION
This PR introduces OpenRouter integration, enabling users to generate commit messages with various free AI models.

**Key Changes:**
- Added `OpenRouterClientConfiguration`, Panel, Service, and SharedState.
- Updated `LLMClientTable` and `AppSettings2` to support OpenRouter.
- Integrated free `nousresearch/hermes-3-llama-3.1-405b:free` 

Models can be accessed here: [OpenRouter Models](https://openrouter.ai/models?max_price=0&order=top-weekly).

**Testing:**
- Verified OpenRouter settings configuration.
- Tested API connection and commit message generation using one of the free models (hermes-3-llama-3.1-405b:free).