### PR TITLE
fix(ui): improve prompt dialog resizing behavior

### DIFF
--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/prompts/PromptDialogSizeState.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/prompts/PromptDialogSizeState.kt
@@ -1,0 +1,22 @@
+package com.github.blarc.ai.commits.intellij.plugin.settings.prompts
+
+import com.intellij.openapi.components.*
+
+@Service(Service.Level.APP)
+@State(name = "PromptDialogSettings", storages = [Storage("AICommitsPromptDialogSettings.xml")])
+class PromptDialogSizeState : PersistentStateComponent<PromptDialogSizeState> {
+    var width: Int = 800
+    var height: Int = 600
+
+    override fun getState(): PromptDialogSizeState? = this
+
+    override fun loadState(state: PromptDialogSizeState) {
+        this.width = state.width
+        this.height = state.height
+    }
+
+    companion object {
+        @JvmStatic
+        fun getInstance(): PromptDialogSizeState = service()
+    }
+}


### PR DESCRIPTION
This commit addresses an issue with the prompt dialog where the size would reset to default on each invocation.  This behavior was particularly disruptive, especially when users preferred a larger dialog to accommodate lengthy prompts or previews.

The solution implemented in this change persists the dialog's dimensions (width and height) across sessions. This ensures that the prompt dialog retains the user's preferred size, enhancing usability and overall experience.  Additionally, the default size of text areas within the dialog has been reduced to 5 rows to provide a more compact initial layout.  The rows are now also resizable, allowing users to customize the dialog layout further.