### PR TITLE
feat(clients): add new Gemini API client

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -109,6 +109,7 @@ dependencies {
     implementation("dev.langchain4j:langchain4j-anthropic")
     implementation("dev.langchain4j:langchain4j-azure-open-ai")
     implementation("dev.langchain4j:langchain4j-hugging-face")
+    implementation("dev.langchain4j:langchain4j-google-ai-gemini")
 
     // tests
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.11.3")

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/AppSettings2.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/AppSettings2.kt
@@ -8,6 +8,7 @@ import com.github.blarc.ai.commits.intellij.plugin.settings.clients.LLMClientCon
 import com.github.blarc.ai.commits.intellij.plugin.settings.clients.anthropic.AnthropicClientConfiguration
 import com.github.blarc.ai.commits.intellij.plugin.settings.clients.azureOpenAi.AzureOpenAiClientConfiguration
 import com.github.blarc.ai.commits.intellij.plugin.settings.clients.gemini.GeminiClientConfiguration
+import com.github.blarc.ai.commits.intellij.plugin.settings.clients.geminiApi.GeminiApiClientConfiguration
 import com.github.blarc.ai.commits.intellij.plugin.settings.clients.huggingface.HuggingFaceClientConfiguration
 import com.github.blarc.ai.commits.intellij.plugin.settings.clients.ollama.OllamaClientConfiguration
 import com.github.blarc.ai.commits.intellij.plugin.settings.clients.openAi.OpenAiClientConfiguration
@@ -57,6 +58,7 @@ class AppSettings2 : PersistentStateComponent<AppSettings2> {
             OllamaClientConfiguration::class,
             QianfanClientConfiguration::class,
             GeminiClientConfiguration::class,
+            GeminiApiClientConfiguration::class,
             AnthropicClientConfiguration::class,
             AzureOpenAiClientConfiguration::class,
             HuggingFaceClientConfiguration::class

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/LLMClientTable.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/LLMClientTable.kt
@@ -6,6 +6,7 @@ import com.github.blarc.ai.commits.intellij.plugin.settings.AppSettings2
 import com.github.blarc.ai.commits.intellij.plugin.settings.clients.anthropic.AnthropicClientConfiguration
 import com.github.blarc.ai.commits.intellij.plugin.settings.clients.azureOpenAi.AzureOpenAiClientConfiguration
 import com.github.blarc.ai.commits.intellij.plugin.settings.clients.gemini.GeminiClientConfiguration
+import com.github.blarc.ai.commits.intellij.plugin.settings.clients.geminiApi.GeminiApiClientConfiguration
 import com.github.blarc.ai.commits.intellij.plugin.settings.clients.huggingface.HuggingFaceClientConfiguration
 import com.github.blarc.ai.commits.intellij.plugin.settings.clients.ollama.OllamaClientConfiguration
 import com.github.blarc.ai.commits.intellij.plugin.settings.clients.openAi.OpenAiClientConfiguration
@@ -149,6 +150,7 @@ class LLMClientTable {
                     OllamaClientConfiguration(),
                     QianfanClientConfiguration(),
                     GeminiClientConfiguration(),
+                    GeminiApiClientConfiguration(),
                     AnthropicClientConfiguration(),
                     AzureOpenAiClientConfiguration(),
                     HuggingFaceClientConfiguration()

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/geminiApi/GeminiApiClientConfiguration.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/geminiApi/GeminiApiClientConfiguration.kt
@@ -1,0 +1,55 @@
+package com.github.blarc.ai.commits.intellij.plugin.settings.clients.geminiApi
+
+import com.github.blarc.ai.commits.intellij.plugin.Icons
+import com.github.blarc.ai.commits.intellij.plugin.settings.clients.LLMClientConfiguration
+import com.github.blarc.ai.commits.intellij.plugin.settings.clients.LLMClientSharedState
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vcs.ui.CommitMessage
+import com.intellij.util.xmlb.annotations.Attribute
+import com.intellij.vcs.commit.AbstractCommitWorkflowHandler
+import javax.swing.Icon
+
+class GeminiApiClientConfiguration : LLMClientConfiguration(
+    "GeminiApi",
+    "gemini-1.5-pro",
+    "0.7"
+) {
+    @Attribute
+    var apiKey: String = "api-key"
+
+    companion object {
+        const val CLIENT_NAME = "GeminiApi"
+    }
+
+    override fun getClientName(): String {
+        return CLIENT_NAME
+    }
+
+    override fun getClientIcon(): Icon {
+        return Icons.GEMINI
+    }
+
+    override fun getSharedState(): LLMClientSharedState {
+        return GeminiApiClientSharedState.getInstance()
+    }
+
+    override fun generateCommitMessage(commitWorkflowHandler: AbstractCommitWorkflowHandler<*, *>, commitMessage: CommitMessage, project: Project) {
+        return GeminiApiClientService.getInstance().generateCommitMessage(this, commitWorkflowHandler, commitMessage, project)
+    }
+
+    // Model names are hard-coded and do not need to be refreshed.
+    override fun getRefreshModelsFunction() = null
+
+    override fun clone(): LLMClientConfiguration {
+        val copy = GeminiApiClientConfiguration()
+        copy.id = id
+        copy.name = name
+        copy.modelId = modelId
+        copy.temperature = temperature
+        copy.apiKey = apiKey
+        return copy
+    }
+
+    override fun panel() = GeminiApiClientPanel(this)
+
+}

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/geminiApi/GeminiApiClientPanel.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/geminiApi/GeminiApiClientPanel.kt
@@ -1,0 +1,52 @@
+package com.github.blarc.ai.commits.intellij.plugin.settings.clients.geminiApi
+
+import GeminiApiClientService
+import com.github.blarc.ai.commits.intellij.plugin.AICommitsBundle.message
+import com.github.blarc.ai.commits.intellij.plugin.notBlank
+import com.github.blarc.ai.commits.intellij.plugin.settings.clients.LLMClientPanel
+import com.intellij.ui.components.JBTextField
+import com.intellij.ui.dsl.builder.Align
+import com.intellij.ui.dsl.builder.Panel
+import com.intellij.ui.dsl.builder.bindText
+import com.intellij.ui.dsl.builder.panel
+
+class GeminiApiClientPanel private constructor(
+    private val clientConfiguration: GeminiApiClientConfiguration,
+    val service: GeminiApiClientService
+) : LLMClientPanel(clientConfiguration) {
+
+    private val projectIdTextField = JBTextField()
+
+    constructor(configuration: GeminiApiClientConfiguration): this(configuration, GeminiApiClientService.getInstance())
+
+    override fun create() = panel {
+        nameRow()
+        apiKeyRow()
+        modelIdRow()
+        temperatureRow()
+        verifyRow()
+    }
+
+    private fun Panel.apiKeyRow() {
+        row {
+            label(message("settings.geminiApi.api-key"))
+                .widthGroup("label")
+
+            cell(projectIdTextField)
+                .bindText(clientConfiguration::apiKey)
+                .resizableColumn()
+                .align(Align.FILL)
+                .validationOnInput { notBlank(it.text) }
+                .comment(message("settings.geminiApi.apk-kay.comment"))
+        }
+
+    }
+
+    override fun verifyConfiguration() {
+        // Configuration passed to panel is already a copy of the original or a new configuration
+        clientConfiguration.modelId = modelComboBox.item
+        clientConfiguration.temperature = temperatureTextField.text
+        clientConfiguration.apiKey = projectIdTextField.text
+        service.verifyConfiguration(clientConfiguration, verifyLabel)
+    }
+}

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/geminiApi/GeminiApiClientService.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/geminiApi/GeminiApiClientService.kt
@@ -1,0 +1,26 @@
+import com.github.blarc.ai.commits.intellij.plugin.settings.clients.LLMClientService
+import com.github.blarc.ai.commits.intellij.plugin.settings.clients.geminiApi.GeminiApiClientConfiguration
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import dev.langchain4j.model.chat.ChatLanguageModel
+import dev.langchain4j.model.googleai.GoogleAiGeminiChatModel
+import kotlinx.coroutines.CoroutineScope
+
+@Service(Service.Level.APP)
+class GeminiApiClientService(private val cs: CoroutineScope) : LLMClientService<GeminiApiClientConfiguration>(cs) {
+
+    companion object {
+        @JvmStatic
+        fun getInstance(): GeminiApiClientService = service()
+    }
+
+    override suspend fun buildChatModel(client: GeminiApiClientConfiguration): ChatLanguageModel {
+        return GoogleAiGeminiChatModel.builder()
+            .apiKey(client.apiKey)
+            .modelName(client.modelId)
+            .temperature(client.temperature.toDouble())
+            .build()
+    }
+
+    override suspend fun buildStreamingChatModel(client: GeminiApiClientConfiguration) = null
+}

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/geminiApi/GeminiApiClientSharedState.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/geminiApi/GeminiApiClientSharedState.kt
@@ -1,0 +1,43 @@
+package com.github.blarc.ai.commits.intellij.plugin.settings.clients.geminiApi
+
+import com.github.blarc.ai.commits.intellij.plugin.settings.clients.LLMClientSharedState
+import com.intellij.openapi.components.*
+import com.intellij.util.xmlb.annotations.XCollection
+
+@Service(Service.Level.APP)
+@State(name = "GeminiApiClientSharedState", storages = [Storage("AICommitsGeminiApi.xml")])
+class GeminiApiClientSharedState : PersistentStateComponent<GeminiApiClientSharedState>, LLMClientSharedState {
+
+    companion object {
+        @JvmStatic
+        fun getInstance(): GeminiApiClientSharedState = service()
+    }
+
+    @XCollection(style = XCollection.Style.v2)
+    override val hosts = mutableSetOf("http://localhost:11434/")
+
+    @XCollection(style = XCollection.Style.v2)
+    override val modelIds: MutableSet<String> = mutableSetOf(
+        "gemini-1.5-pro-latest",
+        "gemini-1.5-pro",
+        "gemini-1.5-pro-001",
+        "gemini-1.5-pro-002",
+        "gemini-1.5-flash-latest",
+        "gemini-1.5-flash",
+        "gemini-1.5-flash-001",
+        "gemini-1.5-flash-002",
+        "gemini-1.5-flash-8b-latest",
+        "gemini-1.5-flash-8b",
+        "gemini-1.5-flash-8b-001",
+        "gemini-1.5-flash-8b-exp-0924",
+        "gemini-1.5-flash-8b-exp-0827",
+        "gemini-1.5-flash-exp-0827"
+    )
+
+    override fun getState(): GeminiApiClientSharedState = this
+
+    override fun loadState(state: GeminiApiClientSharedState) {
+        modelIds += state.modelIds
+        hosts += state.hosts
+    }
+}

--- a/src/main/resources/messages/AiCommitsBundle.properties
+++ b/src/main/resources/messages/AiCommitsBundle.properties
@@ -91,6 +91,9 @@ settings.gemini.project-id=Project ID
 settings.gemini.project-id.comment=Google Cloud project's ID.
 settings.gemini.location=Location
 
+settings.geminiApi.api-key=API key
+settings.geminiApi.apk-kay.comment=Gemini API Key.
+
 settings.anthropic.token.example=sk-ant-api03-TTz_qsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 settings.anthropic.token.comment=You can get your token <a href="https://console.anthropic.com/settings/keys">here.</a>
 settings.anthropic.version=Version


### PR DESCRIPTION
This change introduces a new client for interacting with Google's Gemini API directly. Previously, Gemini models were accessed through the Vertex AI API. While this approach remains functional, using the dedicated Gemini API offers several advantages, most notably the ability to utilize the free tier for Gemini models. This opens up Langchain4j-powered commit message generation to a wider range of users.

The following updates were made to support the new Gemini API client:

    Added langchain4j-google-ai-gemini dependency to build.gradle.kts.
    Integrated the new Gemini API client into the plugin's settings.
    Implemented the Gemini API client configuration panel.
    Created the necessary service and shared state components for the client.

This addition provides a more streamlined and cost-effective way to leverage the power of Gemini models for generating commit messages.