### PR TITLE
Update GeminiGoogleClientService.kt

### DIFF
--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/geminiGoogle/GeminiGoogleClientService.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/geminiGoogle/GeminiGoogleClientService.kt
@@ -29,6 +29,7 @@ class GeminiGoogleClientService(private val cs: CoroutineScope) : LLMClientServi
             .apiKey(token)
             .modelName(client.modelId)
             .temperature(client.temperature.toDouble())
+            .topK(40)
             .build()
     }
 


### PR DESCRIPTION
fix:INVALID_ARGUMENT (code 400) Unable to submit request because it has a topK value of 64 but the supported range is from 1 (inclusive) to 41 (exclusive). Update the value and try again.