### PR TITLE
fix(locale): align language handling with IDE settings (fixes #308)

### DIFF
--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/AICommitsUtils.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/AICommitsUtils.kt
@@ -6,6 +6,7 @@ import com.github.blarc.ai.commits.intellij.plugin.settings.AppSettings2
 import com.github.blarc.ai.commits.intellij.plugin.settings.ProjectSettings
 import com.intellij.credentialStore.CredentialAttributes
 import com.intellij.credentialStore.OneTimeString
+import com.intellij.DynamicBundle
 import com.intellij.ide.passwordSafe.PasswordSafe
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diff.impl.patch.IdeaTextPatchBuilder
@@ -18,6 +19,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.StringWriter
 import java.nio.file.FileSystems
+import java.util.Locale
 
 object AICommitsUtils {
 
@@ -39,7 +41,8 @@ object AICommitsUtils {
     fun constructPrompt(promptContent: String, diff: String, branch: String, hint: String?, project: Project): String {
         var content = promptContent
         val locale = project.service<ProjectSettings>().locale
-        content = content.replace("{locale}", locale.displayLanguage)
+        // lang format: "Language name in English + (ISO 639 lang code) + – + native language name in IDE's locale"; example "French (fr) – français"
+        content = content.replace("{locale}", "${locale.getDisplayLanguage(Locale.ENGLISH)} (${locale.language}) \u2013 ${locale.getDisplayLanguage(locale)}")
         content = content.replace("{branch}", branch)
         content = replaceHint(content, hint)
 
@@ -172,5 +175,9 @@ object AICommitsUtils {
             this.javaClass,
             false
         )
+    }
+
+    fun getIDELocale(): Locale {
+        return DynamicBundle.getLocale() ?: Locale.getDefault()
     }
 }

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/AICommitsUtils.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/AICommitsUtils.kt
@@ -41,8 +41,7 @@ object AICommitsUtils {
     fun constructPrompt(promptContent: String, diff: String, branch: String, hint: String?, project: Project): String {
         var content = promptContent
         val locale = project.service<ProjectSettings>().locale
-        // lang format: "Language name in English + (ISO 639 lang code) + – + native language name in IDE's locale"; example "French (fr) – français"
-        content = content.replace("{locale}", "${locale.getDisplayLanguage(Locale.ENGLISH)} (${locale.language}) \u2013 ${locale.getDisplayLanguage(locale)}")
+        content = content.replace("{locale}", locale.getDisplayLanguage(Locale.ENGLISH))
         content = content.replace("{branch}", branch)
         content = replaceHint(content, hint)
 
@@ -178,6 +177,6 @@ object AICommitsUtils {
     }
 
     fun getIDELocale(): Locale {
-        return DynamicBundle.getLocale() ?: Locale.getDefault()
+        return DynamicBundle.getLocale()
     }
 }

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/AICommitsListCellRenderer.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/AICommitsListCellRenderer.kt
@@ -1,5 +1,6 @@
 package com.github.blarc.ai.commits.intellij.plugin.settings
 
+import com.github.blarc.ai.commits.intellij.plugin.AICommitsUtils
 import com.github.blarc.ai.commits.intellij.plugin.settings.clients.LLMClientConfiguration
 import com.github.blarc.ai.commits.intellij.plugin.settings.prompts.Prompt
 import java.awt.Component
@@ -18,7 +19,9 @@ class AICommitsListCellRenderer : DefaultListCellRenderer() {
         val component = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus)
         when (value) {
             is Locale -> {
-                text = value.displayLanguage
+                val ideLocale = AICommitsUtils.getIDELocale()
+                // lang format: "Language name in IDE's locale + (ISO 639 lang code)"; example for Spanish in IDE "francés (fr)", for IDE in German "Französisch (fr)"
+                text = "${Locale(value.language).getDisplayName(ideLocale)} (${value.language})"
             }
 
             is Prompt -> {

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/AICommitsListCellRenderer.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/AICommitsListCellRenderer.kt
@@ -21,7 +21,7 @@ class AICommitsListCellRenderer : DefaultListCellRenderer() {
             is Locale -> {
                 val ideLocale = AICommitsUtils.getIDELocale()
                 // lang format: "Language name in IDE's locale + (ISO 639 lang code)"; example for Spanish in IDE "francés (fr)", for IDE in German "Französisch (fr)"
-                text = "${Locale(value.language).getDisplayName(ideLocale)} (${value.language})"
+                text = "${Locale.forLanguageTag(value.language).getDisplayLanguage(ideLocale)} (${value.language})"
             }
 
             is Prompt -> {

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/AppSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/AppSettingsConfigurable.kt
@@ -82,6 +82,8 @@ class AppSettingsConfigurable(val project: Project, cs: CoroutineScope) : BoundC
             label(message("settings.locale")).widthGroup("labelPrompt")
             val ideLocale = AICommitsUtils.getIDELocale()
 
+            // Configures locale-aware text comparator for proper language name sorting
+            // Without a Collator, we would get incorrect sorting based on raw Unicode values
             val collator = Collator.getInstance(ideLocale).apply {
                 strength = Collator.TERTIARY
                 decomposition = Collator.CANONICAL_DECOMPOSITION
@@ -99,6 +101,8 @@ class AppSettingsConfigurable(val project: Project, cs: CoroutineScope) : BoundC
             comboBox(locales, AICommitsListCellRenderer())
                 .widthGroup("input")
                 .bindItem(getter = { projectSettings.locale }, setter = { setActiveLocale(it)} )
+
+            contextHelp(message("settings.locale.contextHelp"))
 
             browserLink(message("settings.more-prompts"), AICommitsBundle.URL_PROMPTS_DISCUSSION.toString())
                 .align(AlignX.RIGHT)

--- a/src/main/resources/messages/AiCommitsBundle.properties
+++ b/src/main/resources/messages/AiCommitsBundle.properties
@@ -3,6 +3,7 @@ name=AI Commits
 settings.title=Settings
 settings.general.group.title=AI Commits
 settings.locale=Locale
+settings.locale.contextHelp=Listed locales appear in the IDE's language. Prompts use English locales (e.g., German, French, etc.).
 settings.prompt=Prompt
 settings.report-bug=Report bug
 settings.verifyToken=Verify


### PR DESCRIPTION
Fixes #308 - Improved locale handling for non-English IDE configurations

### Changes:
- Use IDE locale instead of OS system for language displays in settings
- Implement Collator-based sorting for locale list
- Standardize prompt locale to 'English name (code) – Native name'; example "French (fr) – français"