### PR TITLE
fix(locale): ensure correct locale selection in settings dropdown

### DIFF
--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/AppSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/AppSettingsConfigurable.kt
@@ -100,7 +100,10 @@ class AppSettingsConfigurable(val project: Project, cs: CoroutineScope) : BoundC
 
             comboBox(locales, AICommitsListCellRenderer())
                 .widthGroup("input")
-                .bindItem(getter = { projectSettings.locale }, setter = { setActiveLocale(it)} )
+                .bindItem(
+                    getter = { locales.find { it.language == projectSettings.locale.language } ?: Locale.ENGLISH },
+                    setter = { setActiveLocale(it)}
+                )
 
             contextHelp(message("settings.locale.contextHelp"))
 


### PR DESCRIPTION
Fixes an issue where the locale dropdown would incorrectly display the first alphabetical locale (e.g., "Afrikaans" for English) instead of the actual default locale (e.g., "English"). This happened when a user first installed the plugin or didn't set locale directly before. Now such user will see selected English (en) correctly matching default in prompts.

Incorrect language in dropdown (fixed by this commit):
![AI_commits_default_EN](https://github.com/user-attachments/assets/fe04bc86-8c67-4d95-8c83-c779271a3145)