### PR TITLE
fix(settings): restore modelId to base conf, keep temperature in clients & remove it from table

### DIFF
--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/LLMClientConfiguration.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/LLMClientConfiguration.kt
@@ -17,7 +17,8 @@ import java.util.*
 import javax.swing.Icon
 
 abstract class LLMClientConfiguration(
-    @Attribute var name: String
+    @Attribute var name: String,
+    @Attribute var modelId: String
 ) : Cloneable, Comparable<LLMClientConfiguration>, AnAction() {
 
     @Attribute

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/LLMClientPanel.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/LLMClientPanel.kt
@@ -60,7 +60,7 @@ abstract class LLMClientPanel(
         }
     }
 
-    open fun Panel.modelIdRow(property: MutableProperty<String>, labelKey: String = "settings.llmClient.modelId", commentKey: String? = null) {
+    open fun Panel.modelIdRow(labelKey: String = "settings.llmClient.modelId", commentKey: String? = null) {
         row {
             label(message(labelKey))
                 .widthGroup("label")
@@ -69,10 +69,10 @@ abstract class LLMClientPanel(
                 .applyToComponent {
                     isEditable = true
                 }
-                .bindItem({ property.get() }, {
+                .bindItem({ clientConfiguration.modelId }, {
                     if (it != null) {
                         clientConfiguration.addModelId(modelComboBox.item)
-                        property.set(it)
+                        clientConfiguration.modelId = it
                     }
                 })
                 .align(Align.FILL)

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/LLMClientTable.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/LLMClientTable.kt
@@ -59,8 +59,7 @@ class LLMClientTable {
     private fun createTableModel(): ListTableModel<LLMClientConfiguration> = ListTableModel(
         arrayOf(
             createColumn<LLMClientConfiguration, LLMClientConfiguration>(message("settings.llmClient.name")) { llmClient -> llmClient },
-            createColumn<LLMClientConfiguration, String>(message("settings.llmClient.modelId")) { llmClient -> llmClient.modelId },
-            createColumn(message("settings.llmClient.temperature")) { llmClient -> llmClient.temperature }
+            createColumn<LLMClientConfiguration, String>(message("settings.llmClient.modelId")) { llmClient -> llmClient.modelId }
         ),
         llmClients.toList()
     )

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/amazonBedrock/AmazonBedrockClientConfiguration.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/amazonBedrock/AmazonBedrockClientConfiguration.kt
@@ -14,11 +14,10 @@ import software.amazon.awssdk.regions.Region
 import javax.swing.Icon
 
 class AmazonBedrockClientConfiguration : LLMClientConfiguration(
-    "Amazon Bedrock"
+    "Amazon Bedrock",
+    "us.amazon.nova-lite-v1:0"
 ) {
 
-    @Attribute
-    var modelId: String = "us.amazon.nova-lite-v1:0"
     @Attribute
     var temperature: String = "0.7"
     @Attribute

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/amazonBedrock/AmazonBedrockClientPanel.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/amazonBedrock/AmazonBedrockClientPanel.kt
@@ -30,7 +30,7 @@ class AmazonBedrockClientPanel private constructor(
 
     override fun create() = panel {
         nameRow()
-        modelIdRow(clientConfiguration::modelId.toMutableProperty(), commentKey = "settings.amazonBedrock.modelId.comment")
+        modelIdRow(commentKey = "settings.amazonBedrock.modelId.comment")
         temperatureRow(clientConfiguration::temperature.toMutableProperty())
         timeoutRow(clientConfiguration::timeout)
         credentialsProviderRow()

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/anthropic/AnthropicClientConfiguration.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/anthropic/AnthropicClientConfiguration.kt
@@ -12,10 +12,9 @@ import kotlinx.coroutines.Job
 import javax.swing.Icon
 
 class AnthropicClientConfiguration : LLMClientConfiguration(
-    "Anthropic"
+    "Anthropic",
+    AnthropicChatModelName.CLAUDE_3_5_SONNET_20240620.toString()
 ) {
-    @Attribute
-    var modelId: String = AnthropicChatModelName.CLAUDE_3_5_SONNET_20240620.toString()
     @Attribute
     var temperature: String = "0.7"
     @Attribute

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/anthropic/AnthropicClientPanel.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/anthropic/AnthropicClientPanel.kt
@@ -22,7 +22,7 @@ class AnthropicClientPanel private constructor(
     override fun create() = panel {
         nameRow()
         hostRow(clientConfiguration::host.toNullableProperty())
-        modelIdRow(clientConfiguration::modelId.toMutableProperty())
+        modelIdRow()
         temperatureRow(clientConfiguration::temperature.toMutableProperty())
         timeoutRow(clientConfiguration::timeout)
         tokenRow()

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/azureOpenAi/AzureOpenAiClientConfiguration.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/azureOpenAi/AzureOpenAiClientConfiguration.kt
@@ -11,11 +11,10 @@ import kotlinx.coroutines.Job
 import javax.swing.Icon
 
 class AzureOpenAiClientConfiguration : LLMClientConfiguration(
-    CLIENT_NAME
+    CLIENT_NAME,
+    ""
 ) {
 
-    @Attribute
-    var modelId: String = ""
     @Attribute
     var temperature: String = "0.7"
     @Attribute

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/azureOpenAi/AzureOpenAiClientPanel.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/azureOpenAi/AzureOpenAiClientPanel.kt
@@ -22,7 +22,7 @@ class AzureOpenAiClientPanel private constructor(
         hostRow(clientConfiguration::host.toNullableProperty(), "settings.azureOpenAi.host")
         timeoutRow(clientConfiguration::timeout)
         tokenRow()
-        modelIdRow(clientConfiguration::modelId.toMutableProperty(), "settings.azureOpenAi.modelId")
+        modelIdRow("settings.azureOpenAi.modelId")
         temperatureRow(clientConfiguration::temperature.toMutableProperty())
         topPDoubleRow(topPTextField, clientConfiguration::topP.toNullableProperty())
         verifyRow()

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/geminiGoogle/GeminiGoogleClientConfiguration.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/geminiGoogle/GeminiGoogleClientConfiguration.kt
@@ -12,10 +12,9 @@ import kotlinx.coroutines.Job
 import javax.swing.Icon
 
 class GeminiGoogleClientConfiguration : LLMClientConfiguration(
-    "Gemini Google"
+    "Gemini Google",
+    "gemini-1.5-pro"
 ) {
-    @Attribute
-    var modelId: String = "gemini-1.5-pro"
     @Attribute
     var temperature: String = "0.7"
     @Attribute

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/geminiGoogle/GeminiGoogleClientPanel.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/geminiGoogle/GeminiGoogleClientPanel.kt
@@ -22,7 +22,7 @@ class GeminiGoogleClientPanel private constructor(
     override fun create() = panel {
         nameRow()
         tokenRow()
-        modelIdRow(clientConfiguration::modelId.toMutableProperty())
+        modelIdRow()
         temperatureRow(clientConfiguration::temperature.toMutableProperty())
         topKRow(topKTextField, clientConfiguration::topK.toNullableProperty())
         topPDoubleRow(topPTextField, clientConfiguration::topP.toNullableProperty())

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/geminiVertex/GeminiClientConfiguration.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/geminiVertex/GeminiClientConfiguration.kt
@@ -12,10 +12,9 @@ import javax.swing.Icon
 // Can not rename this class because of backwards compatibility
 // with persistent component - AppSettings2
 class GeminiClientConfiguration : LLMClientConfiguration(
-    "Gemini Vertex"
+    "Gemini Vertex",
+    "gemini-pro"
 ) {
-    @Attribute
-    var modelId: String = "gemini-pro"
     @Attribute
     var temperature: String = "0.7"
     @Attribute

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/geminiVertex/GeminiVertexClientPanel.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/geminiVertex/GeminiVertexClientPanel.kt
@@ -22,7 +22,7 @@ class GeminiVertexClientPanel private constructor(
         nameRow()
         projectIdRow()
         locationRow()
-        modelIdRow(clientConfiguration::modelId.toMutableProperty())
+        modelIdRow()
         temperatureRow(clientConfiguration::temperature.toMutableProperty())
         topKRow(topKTextField, clientConfiguration::topK.toNullableProperty())
         topPFloatRow(topPTextField, clientConfiguration::topP.toNullableProperty())

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/githubModels/GitHubModelsClientConfiguration.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/githubModels/GitHubModelsClientConfiguration.kt
@@ -11,10 +11,9 @@ import kotlinx.coroutines.Job
 import javax.swing.Icon
 
 class GitHubModelsClientConfiguration : LLMClientConfiguration(
-    "GitHub Models"
+    "GitHub Models",
+    "gpt-4o-mini"
 ) {
-    @Attribute
-    var modelId: String = "gpt-4o-mini"
     @Attribute
     var temperature: String = "0.7"
     @Attribute

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/githubModels/GitHubModelsClientPanel.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/githubModels/GitHubModelsClientPanel.kt
@@ -21,7 +21,7 @@ class GitHubModelsClientPanel private constructor(
         nameRow()
         timeoutRow(clientConfiguration::timeout)
         tokenRow()
-        modelIdRow(clientConfiguration::modelId.toMutableProperty())
+        modelIdRow()
         temperatureRow(clientConfiguration::temperature.toMutableProperty())
         topPDoubleRow(topPTextField, clientConfiguration::topP.toNullableProperty())
         verifyRow()

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/huggingface/HuggingFaceClientConfiguration.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/huggingface/HuggingFaceClientConfiguration.kt
@@ -12,11 +12,10 @@ import kotlinx.coroutines.Job
 import javax.swing.Icon
 
 class HuggingFaceClientConfiguration : LLMClientConfiguration(
-    "HuggingFace"
+    "HuggingFace",
+    HuggingFaceModelName.TII_UAE_FALCON_7B_INSTRUCT
 ) {
 
-    @Attribute
-    var modelId: String = HuggingFaceModelName.TII_UAE_FALCON_7B_INSTRUCT
     @Attribute
     var temperature: String = "0.7"
     @Attribute

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/huggingface/HuggingFaceClientPanel.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/huggingface/HuggingFaceClientPanel.kt
@@ -24,7 +24,7 @@ class HuggingFaceClientPanel private constructor(
         nameRow()
         timeoutRow(clientConfiguration::timeout)
         tokenRow()
-        modelIdRow(clientConfiguration::modelId.toMutableProperty())
+        modelIdRow()
         temperatureRow(clientConfiguration::temperature.toMutableProperty())
         maxNewTokens()
         waitForModel()

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/mistral/MistralAIClientConfiguration.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/mistral/MistralAIClientConfiguration.kt
@@ -12,10 +12,9 @@ import kotlinx.coroutines.Job
 import javax.swing.Icon
 
 class MistralAIClientConfiguration : LLMClientConfiguration(
-    "MistralAI"
+    "MistralAI",
+    MistralAiChatModelName.OPEN_MISTRAL_7B.toString()
 ) {
-    @Attribute
-    var modelId: String = MistralAiChatModelName.OPEN_MISTRAL_7B.toString()
     @Attribute
     var temperature: String = "0.7"
     @Attribute

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/mistral/MistralAIClientPanel.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/mistral/MistralAIClientPanel.kt
@@ -21,7 +21,7 @@ class MistralAIClientPanel private constructor(
 
     override fun create() = panel {
         nameRow()
-        modelIdRow(clientConfiguration::modelId.toMutableProperty())
+        modelIdRow()
         tokenRow()
         maxTokens()
         temperatureRow(clientConfiguration::temperature.toMutableProperty())

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/ollama/OllamaClientConfiguration.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/ollama/OllamaClientConfiguration.kt
@@ -10,11 +10,10 @@ import kotlinx.coroutines.Job
 import javax.swing.Icon
 
 class OllamaClientConfiguration : LLMClientConfiguration(
-    "Ollama"
+    "Ollama",
+    "llama3"
 ) {
 
-    @Attribute
-    var modelId: String = "llama3"
     @Attribute
     var temperature: String = "0.7"
     @Attribute

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/ollama/OllamaClientPanel.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/ollama/OllamaClientPanel.kt
@@ -22,7 +22,7 @@ class OllamaClientPanel private constructor(
         nameRow()
         hostRow(clientConfiguration::host.toNullableProperty())
         timeoutRow(clientConfiguration::timeout)
-        modelIdRow(clientConfiguration::modelId.toMutableProperty())
+        modelIdRow()
         temperatureRow(clientConfiguration::temperature.toMutableProperty())
         topKRow(topKTextField, clientConfiguration::topK.toNullableProperty())
         topPDoubleRow(topPTextField, clientConfiguration::topP.toNullableProperty())

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/openAi/OpenAiClientConfiguration.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/openAi/OpenAiClientConfiguration.kt
@@ -10,11 +10,10 @@ import kotlinx.coroutines.Job
 import javax.swing.Icon
 
 class OpenAiClientConfiguration : LLMClientConfiguration(
-    "OpenAI"
+    "OpenAI",
+    "gpt-3.5-turbo"
 ) {
 
-    @Attribute
-    var modelId: String = "gpt-3.5-turbo"
     @Attribute
     var temperature: String = "0.7"
     @Attribute

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/openAi/OpenAiClientPanel.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/openAi/OpenAiClientPanel.kt
@@ -19,7 +19,7 @@ class OpenAiClientPanel(private val clientConfiguration: OpenAiClientConfigurati
         hostRow(clientConfiguration::host.toNullableProperty())
         timeoutRow(clientConfiguration::timeout)
         tokenRow()
-        modelIdRow(clientConfiguration::modelId.toMutableProperty())
+        modelIdRow()
         organizationIdRow()
         temperatureRow(clientConfiguration::temperature.toMutableProperty(), ValidationInfoBuilder::temperatureValidNullable)
         topPDoubleRow(topPTextField, clientConfiguration::topP.toNullableProperty())

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/qianfan/QianfanClientConfiguration.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/qianfan/QianfanClientConfiguration.kt
@@ -11,10 +11,9 @@ import kotlinx.coroutines.Job
 import javax.swing.Icon
 
 class QianfanClientConfiguration : LLMClientConfiguration(
-    "Qianfan"
+    "Qianfan",
+    QianfanChatModelNameEnum.ERNIE_SPEED_128K.modelName
 ) {
-    @Attribute
-    var modelId: String = QianfanChatModelNameEnum.ERNIE_SPEED_128K.modelName
     @Attribute
     var temperature: String = "0.7"
     @Attribute

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/qianfan/QianfanClientPanel.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/qianfan/QianfanClientPanel.kt
@@ -16,7 +16,7 @@ class QianfanClientPanel(private val clientConfiguration: QianfanClientConfigura
     override fun create() = panel {
         nameRow()
         hostRow(clientConfiguration::host.toNullableProperty())
-        modelIdRow(clientConfiguration::modelId.toMutableProperty())
+        modelIdRow()
 
         row {
             label(message("settings.qianfan.apiKey"))


### PR DESCRIPTION
Partially reverts commit 71669b0 to restore` modelId` as a shared attribute in `LLMClientConfiguration` while keeping `temperature` as a per-client attribute. Removes `temperature` from the table, fixing the remaining build issues.

Changes:
- Add modelId back as constructor parameter in LLMClientConfiguration
- Update all 11 client configuration subclasses to pass modelId to parent
- Restore LLMClientPanel.modelIdRow() to access modelId directly
- Update all 11 panel subclasses to call modelIdRow() without property parameter
- Remove temperature column from LLMClientTable (now client-specific)
- Keep temperature as @Attribute property in individual client configurations

This ensures modelId remains accessible in the shared settings table while allowing each client to define its own temperature handling as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)