### PR TITLE
refactor(LLMClientConfiguration): remove the think tag

### DIFF
--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/LLMClientConfiguration.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/LLMClientConfiguration.kt
@@ -74,7 +74,9 @@ abstract class LLMClientConfiguration(
         prompt: String,
         result: String
     ) {
-        commitWorkflowHandler.setCommitMessage(result)
+        // Remove <think>content</think> style tags and their content
+        val cleanedResult = result.replace(Regex("<think>[\\s\\S]*?</think>", RegexOption.IGNORE_CASE), "").trim()
+        commitWorkflowHandler.setCommitMessage(cleanedResult)
     }
 
     abstract fun generateCommitMessage(commitWorkflowHandler: AbstractCommitWorkflowHandler<*, *>, project: Project)


### PR DESCRIPTION
This PR removes the `<think>xxxx</think>` tag from the output result.