### PR TITLE
fix(commit): clear existing message before generating new one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/test/**/build/
 
 ### IntelliJ IDEA ###
+.intellijPlatform/
 .idea/modules.xml
 .idea/jarRepositories.xml
 .idea/compiler.xml

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/LlmClientConfiguration.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/LlmClientConfiguration.kt
@@ -93,6 +93,8 @@ abstract class LlmClientConfiguration(
         result: String
     ) {
         val cleanedResult = result.replace(getCleanUpRegex(), "").trim()
+        // Clear existing message first, then set the new one
+        commitWorkflowHandler.setCommitMessage("")
         commitWorkflowHandler.setCommitMessage(cleanedResult)
     }
 

--- a/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/LlmServiceBase.kt
+++ b/src/main/kotlin/com/github/blarc/ai/commits/intellij/plugin/settings/clients/LlmServiceBase.kt
@@ -52,9 +52,10 @@ abstract class LlmServiceBase<C : LlmClientConfiguration>(protected val coroutin
         }
 
         val branch = getCommonBranch(includedChanges, project)
+        // Pass null to avoid including the old commit message in the prompt
         val prompt = constructPrompt(
             project.service<ProjectSettings>().activePrompt.content,
-            diff, branch, commitWorkflowHandler.getCommitMessage(), project
+            diff, branch, null, project
         )
 
         return Pair(diff, prompt)


### PR DESCRIPTION
## Problem

When there's an existing commit message in the commit dialog and you click "Generate Commit Message", the plugin fails to generate a new message. Users have to manually clear the commit message field every time before generating, which is frustrating and breaks the workflow.

## Root Cause

Two issues were identified:

1. **Old message passed to prompt**: The existing commit message was being passed to `constructPrompt()`, which could interfere with the LLM's generation
2. **Message field not clearing**: The commit message field wasn't being cleared before setting the new generated message, causing the old content to persist

## Solution

1. Pass `null` instead of the existing commit message to `constructPrompt()` in `LlmServiceBase.kt`
2. Clear the commit message field (`setCommitMessage("")`) before setting the newly generated message in `LlmClientConfiguration.kt`

## Testing

- Tested with an existing commit message in the dialog
- Clicking generate now properly clears and replaces with newly generated message
- Works correctly on fresh/empty commit dialogs as well