### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ Please see [LICENSE](LICENSE) for details.
 
 ## Star History
 
-<a href="https://star-history.com/#Blarc/ai-commits-intellij-plugin&Date">
+<a href="https://star-history.dera.page/#Blarc/ai-commits-intellij-plugin&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Blarc/ai-commits-intellij-plugin&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Blarc/ai-commits-intellij-plugin&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Blarc/ai-commits-intellij-plugin&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Blarc/ai-commits-intellij-plugin&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Blarc/ai-commits-intellij-plugin&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Blarc/ai-commits-intellij-plugin&type=Date" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart in the README is currently broken: GitHub stargazer API restrictions have stopped the upstream star-history service from rendering the chart.

This PR points the chart at star-history.dera.page, a working alternative that uses a different data source requiring no API token, restoring the chart for the repository. The badge is left untouched.